### PR TITLE
refactor(prompts): target analogy instructions to user expertise

### DIFF
--- a/prompts/inline_commands/analogy.md
+++ b/prompts/inline_commands/analogy.md
@@ -13,12 +13,7 @@ You are transforming study notes for a learner.
 
 ## Action: ANALOGY
 
-Explain the following concept using an analogy tailored to the learner's background:
-
-- For Software Engineering: use programming analogies (functions, classes, APIs, version control)
-- For Data Science/ML: use data science analogies (models, pipelines, features, training)
-- For Statistics: use statistical analogies (distributions, sampling, inference)
-- For Domain Novice: use everyday real-world analogies
+{analogy_instruction}
 
 ## Instructions
 1. Create an analogy that explains the selected text


### PR DESCRIPTION
Replace generic 4-domain list in analogy prompt with targeted instruction based on user's prior_expertise field. Reduces prompt tokens and removes ambiguity for the LLM.

- Add ANALOGY_INSTRUCTIONS mapping in inline_commands.py
- Update analogy.md to use {analogy_instruction} placeholder
- Refactor prompt filling to use format_kwargs dict pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)